### PR TITLE
Add Feature: Enter private chat room

### DIFF
--- a/backend/src/controllers/privateChatHandler.ts
+++ b/backend/src/controllers/privateChatHandler.ts
@@ -10,14 +10,15 @@ const privateChatHandler = (socket: Socket, io: Server) => {
 
   socket.on('invite accepted', (inviterId) => {
     console.log(`${socket.id} accepted chat with ${inviterId}`)
-
+    const roomId = `${inviterId}-room`
+    const roomData = { roomId: roomId, users: [inviterId , socket.id] }
+    
     // Add invitee and inviter join a private room
-    const privateRoom = `${inviterId}-room`
-    io.in(socket.id).socketsJoin(privateRoom)
-    io.in(inviterId).socketsJoin(privateRoom)
+    io.in(socket.id).socketsJoin(roomId)
+    io.in(inviterId).socketsJoin(roomId)
 
     // Send invite request with inviter id to invitee
-    io.to(privateRoom).emit('enter chat room', privateRoom)
+    io.to(roomId).emit('enter chat room', roomData)
   })
 
   socket.on('decline invite', (inviterId) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { setNewUser, setId } from './app/features/userSlice';
 import { getAllActiveUsers } from './app/features/activeUsersSlice';
 import { setModal } from './app/features/modalSlice';
 import { setNotification, resetNotification } from './app/features/notificationSlice';
+import PrivateRoom from './pages/PrivateRoom';
 
 const App: React.FC = () => {
   const dispatch = useAppDispatch()
@@ -83,16 +84,13 @@ const App: React.FC = () => {
       setTimeout(() => dispatch(resetNotification()), 5000)
     } 
   })
-  socket.on('enter chat room', roomId => {
-    console.log('enter room: ', roomId)
-    dispatch(resetNotification())
-  })
  
   return (
     <Router>
       <div className="App">
         <Routes>
           <Route path='/' element={<Home />}/>
+          <Route path='/p-room/:id' element={<PrivateRoom />} />
           <Route path='/testroom' element={<TestRoom />} />
         </Routes>
       </div>

--- a/frontend/src/app/features/roomSlice.ts
+++ b/frontend/src/app/features/roomSlice.ts
@@ -12,7 +12,7 @@ export const roomSlice = createSlice({
   reducers: {
     setRoom: (state, action: PayloadAction<Room>) => {
       state.roomId = action.payload.roomId
-      state.users = action.payload.users
+      state.users = state.users.concat(action.payload.users)
     },
     resetRoom: (state) => {
       state.roomId = ''

--- a/frontend/src/app/features/roomSlice.ts
+++ b/frontend/src/app/features/roomSlice.ts
@@ -1,0 +1,26 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { Room } from './types'
+
+const initialState: Room = {
+  roomId: '',
+  users: [],
+}
+
+export const roomSlice = createSlice({
+  name: 'room',
+  initialState,
+  reducers: {
+    setRoom: (state, action: PayloadAction<Room>) => {
+      state.roomId = action.payload.roomId
+      state.users = action.payload.users
+    },
+    resetRoom: (state) => {
+      state.roomId = ''
+      state.users = []
+    }
+  }
+})
+
+export const { setRoom, resetRoom } = roomSlice.actions
+
+export default roomSlice.reducer

--- a/frontend/src/app/features/types.ts
+++ b/frontend/src/app/features/types.ts
@@ -25,5 +25,5 @@ export interface Notification {
 
 export interface Room {
   roomId: string;
-  users: User[];
+  users: string[];
 }

--- a/frontend/src/app/features/types.ts
+++ b/frontend/src/app/features/types.ts
@@ -22,3 +22,8 @@ export interface Notification {
   isLoading: boolean;
   isActive: boolean;
 }
+
+export interface Room {
+  roomId: string;
+  users: User[];
+}

--- a/frontend/src/app/store.tsx
+++ b/frontend/src/app/store.tsx
@@ -3,13 +3,15 @@ import userReducer from './features/userSlice';
 import activeUsersReducer from './features/activeUsersSlice';
 import modalSlice from './features/modalSlice';
 import notificationSlice from './features/notificationSlice';
+import roomSlice from './features/roomSlice';
 
 export const store = configureStore({
   reducer: {
     user: userReducer,
     activeUsers: activeUsersReducer,
     modal: modalSlice,
-    notification: notificationSlice
+    notification: notificationSlice,
+    room: roomSlice
   },
 })
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import Layout from '../components/Layout';
 import NewUserForm from '../components/NewUserForm';
 import { useAppSelector, useAppDispatch } from '../app/hooks';
 import { resetNotification } from '../app/features/notificationSlice';
+import { setRoom } from '../app/features/roomSlice';
 import Modal from '../components/Modal';
 import Notification from '../components/Notification';
 import { SocketContext } from '../context/socket';
@@ -18,10 +19,10 @@ const Home = () => {
   const notifiactionActive = useAppSelector(state => state.notification.isActive)
 
   // had to move this socket from App to Home because the navigate method had errors inside App
-  socket.on('enter chat room', roomId => {
-    console.log('enter room: ', roomId)
+  socket.on('enter chat room', roomData => {
     dispatch(resetNotification())
-    navigate(`/p-room/${roomId}`)
+    dispatch(setRoom({ roomId: roomData.roomId, users: roomData.users}))
+    navigate(`/p-room/${roomData.roomId}`)
   })
 
   return (

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,14 +1,28 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
 import ActiveUsers from '../components/ActiveUsers';
 import Layout from '../components/Layout';
 import NewUserForm from '../components/NewUserForm';
-import { useAppSelector } from '../app/hooks';
+import { useAppSelector, useAppDispatch } from '../app/hooks';
+import { resetNotification } from '../app/features/notificationSlice';
 import Modal from '../components/Modal';
 import Notification from '../components/Notification';
+import { SocketContext } from '../context/socket';
 
 const Home = () => {
+  const navigate = useNavigate()
+  const socket = useContext(SocketContext)
+  const dispatch = useAppDispatch();
+
   const username = useAppSelector(state => state.user.username)
   const notifiactionActive = useAppSelector(state => state.notification.isActive)
+
+  // had to move this socket from App to Home because the navigate method had errors inside App
+  socket.on('enter chat room', roomId => {
+    console.log('enter room: ', roomId)
+    dispatch(resetNotification())
+    navigate(`/p-room/${roomId}`)
+  })
 
   return (
     <Layout>

--- a/frontend/src/pages/PrivateRoom.tsx
+++ b/frontend/src/pages/PrivateRoom.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Layout from '../components/Layout';
+
+const PrivateRoom = () => {
+  return (
+    <Layout>
+      Private chat room
+    </Layout>
+  )
+}
+
+export default PrivateRoom

--- a/frontend/src/pages/PrivateRoom.tsx
+++ b/frontend/src/pages/PrivateRoom.tsx
@@ -1,10 +1,20 @@
 import React from 'react';
 import Layout from '../components/Layout';
+import { useAppSelector } from '../app/hooks';
 
 const PrivateRoom = () => {
+  const room = useAppSelector(state => state.room)
+  const userId = useAppSelector(state => state.user.id)
+
+  const userHasAccess = room.users.includes(userId)
+
+  // if user leaves room and comes back, get room data again, use a useEffect
+
   return (
     <Layout>
       Private chat room
+      
+      {userHasAccess ? <p>User has access</p> : <p>No access</p>}
     </Layout>
   )
 }

--- a/frontend/src/pages/PrivateRoom.tsx
+++ b/frontend/src/pages/PrivateRoom.tsx
@@ -1,17 +1,28 @@
 import React from 'react';
 import Layout from '../components/Layout';
-import { useAppSelector } from '../app/hooks';
+import { setNotification, resetNotification } from '../app/features/notificationSlice';
+import { useAppSelector, useAppDispatch } from '../app/hooks';
 import { useNavigate } from 'react-router-dom';
 
 const PrivateRoom = () => {
   const navigate = useNavigate()
+  const dispatch = useAppDispatch()
   const room = useAppSelector(state => state.room)
   const userId = useAppSelector(state => state.user.id)
 
   const userHasAccess = room.users.includes(userId)
 
   if (!userHasAccess) {
+    
+    const notificationData = {
+      notificationContent: 'You do not have access to this room.',
+      notificationType: 'is-warning',
+      isLoading: false,
+      isActive: true,
+      }
+    dispatch(setNotification(notificationData))
     navigate('/')
+    setTimeout(() => dispatch(resetNotification()), 5000)
   }
 
   // if user leaves room and comes back, get room data and recheck if user has access, use a useEffect

--- a/frontend/src/pages/PrivateRoom.tsx
+++ b/frontend/src/pages/PrivateRoom.tsx
@@ -14,7 +14,7 @@ const PrivateRoom = () => {
     navigate('/')
   }
 
-  // if user leaves room and comes back, get room data again, use a useEffect
+  // if user leaves room and comes back, get room data and recheck if user has access, use a useEffect
 
   return (
     <Layout>

--- a/frontend/src/pages/PrivateRoom.tsx
+++ b/frontend/src/pages/PrivateRoom.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import Layout from '../components/Layout';
 import { useAppSelector } from '../app/hooks';
+import { useNavigate } from 'react-router-dom';
 
 const PrivateRoom = () => {
+  const navigate = useNavigate()
   const room = useAppSelector(state => state.room)
   const userId = useAppSelector(state => state.user.id)
 
   const userHasAccess = room.users.includes(userId)
+
+  if (!userHasAccess) {
+    navigate('/')
+  }
 
   // if user leaves room and comes back, get room data again, use a useEffect
 


### PR DESCRIPTION
### Description
This PR adds the feature to redirect users to a private chat room after an invite is sent and accepted.

When an invite is accepted, the privateChatHandler in the back-end adds the inviter and invitee users to a private room with `socketJoin`. The handler sends the room data which consists of the `roomId` and `users` list to each user. 

When the room data is received by the front-end, the room data is saved to room state and the user is redirected to the private room page. The private room page checks if the user has access by checking if the user's ID is included in the room state.  If a user that does not have access to the room navigates to the room page, they will be redirected to the home page.

### Type
- [x] New feature
- [ ] Refactoring
- [ ] Bug-fix
- [ ] DevOps
- [ ] Testing

### Demo

https://user-images.githubusercontent.com/54559570/146616332-25805067-a626-4446-8de4-394cba06c14b.mp4


