### PR TITLE
Fix Bug: Cannot update a component ('BrowserRouter') while rendering a different component ('PrivateRoom')

### DIFF
--- a/frontend/src/pages/PrivateRoom.tsx
+++ b/frontend/src/pages/PrivateRoom.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import Layout from '../components/Layout';
 import { setNotification, resetNotification } from '../app/features/notificationSlice';
 import { useAppSelector, useAppDispatch } from '../app/hooks';
-import { useNavigate } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 
 const PrivateRoom = () => {
-  const navigate = useNavigate()
   const dispatch = useAppDispatch()
   const room = useAppSelector(state => state.room)
   const userId = useAppSelector(state => state.user.id)
@@ -21,19 +20,17 @@ const PrivateRoom = () => {
       isActive: true,
       }
     dispatch(setNotification(notificationData))
-    navigate('/')
     setTimeout(() => dispatch(resetNotification()), 5000)
+    return <Navigate to="/" />
+  } else {
+    return (
+      <Layout>
+        Private chat room
+        
+        {userHasAccess ? <p>User has access</p> : <p>No access</p>}
+      </Layout>
+    )
   }
-
-  // if user leaves room and comes back, get room data and recheck if user has access, use a useEffect
-
-  return (
-    <Layout>
-      Private chat room
-      
-      {userHasAccess ? <p>User has access</p> : <p>No access</p>}
-    </Layout>
-  )
 }
 
 export default PrivateRoom


### PR DESCRIPTION
## Description

This pull request resolves the warning which occurs when a user with no access enters a private room and is redirected to the home page.

```
   Warning: Cannot update a component (`BrowserRouter`) while rendering a different component (`PrivateRoom`). To locate the bad setState() call inside `PrivateRoom`, follow the stack trace as described in <https://reactjs.org/link/setstate-in-render>
at PrivateRoom (<http://localhost:3000/static/js/main.chunk.js:3366:88>)
at Routes (<http://localhost:3000/static/js/vendors~main.chunk.js:43297:5>)
at div
at Router (<http://localhost:3000/static/js/vendors~main.chunk.js:43230:15>)
at BrowserRouter (<http://localhost:3000/static/js/vendors~main.chunk.js:42745:5>)
at App (<http://localhost:3000/static/js/main.chunk.js:73:85>)
at Provider (<http://localhost:3000/static/js/vendors~main.chunk.js:40183:20>)
```

When the user is redirected to the home page with the `useNavigate` hook, the PrivateRoom content is still being rendered.

To resolve this warning, the content of PrivateRoom is only rendered when `userHasAccess` is `true`.  When `userHasAccess` is `false`, the `Navigate` component is returned.