### PR TITLE
Feature: Add video to private chat

### DIFF
--- a/backend/src/controllers/privateChatHandler.ts
+++ b/backend/src/controllers/privateChatHandler.ts
@@ -1,5 +1,8 @@
 import { Server, Socket } from 'socket.io';
 
+let peer1: string;
+let peer2: string;
+
 const privateChatHandler = (socket: Socket, io: Server) => {
   socket.on('invite private chat', (inviteeId) => {
     console.log(`${socket.id} invited ${inviteeId} to a chat`)
@@ -33,6 +36,47 @@ const privateChatHandler = (socket: Socket, io: Server) => {
     
     io.to(sentMessageData.roomId).emit('receive chat message', messageData);
     console.log('message: ' + messageData.msg);
+  })
+
+  socket.on('start video request', (users: string[]) => {
+    peer1 = socket.id
+    peer2 = users.find(user => user !== socket.id)!
+    
+    console.log('start video request')
+
+    if (peer2) {
+      io.to(peer2).emit('start video invite')
+    }
+  })
+
+  socket.on('video request accepted', () => {
+    console.log('send video ready to ', peer1)
+    io.to(peer1).emit('video ready')
+  })
+
+  socket.on('video offer', ({sdp}) => {
+    console.log(`send get video offer to ${peer2}`)
+    
+    if (socket.id === peer1) {
+      io.to(peer2).emit('get video offer', sdp)
+    }
+  })
+
+  socket.on('video answer', ({sdp}) => {
+    console.log(`answer - send get video answer to ${peer1}`)
+    io.to(peer1).emit('get video answer', sdp)
+  })
+
+  socket.on('candidate', ({candidate}) => {
+    console.log(`ice candidate from ${socket.id}`)
+    
+    if (socket.id === peer1) {
+      console.log('send get candidate to peer2')
+      io.to(peer2).emit('get candidate', candidate)
+    } else {
+      console.log('send get candidate to peer1')
+      io.to(peer1).emit('get candidate', candidate)
+    }
   })
 
   socket.on('end chat', (roomId) => {

--- a/backend/src/controllers/privateChatHandler.ts
+++ b/backend/src/controllers/privateChatHandler.ts
@@ -81,6 +81,8 @@ const privateChatHandler = (socket: Socket, io: Server) => {
 
   socket.on('end chat', (roomId) => {
     console.log(`end chat for room ${roomId}`)
+    io.to(peer1).emit('end video request')
+    io.to(peer2).emit('end video request')
     io.to(roomId).emit('close chat room')
   })
 }

--- a/backend/src/controllers/videoHandler.ts
+++ b/backend/src/controllers/videoHandler.ts
@@ -18,6 +18,7 @@ let clientCaller: user = {
 const streamPeers = (socket: Socket, io: Server) => {
   
   socket.on('userEnterRoom', username => {
+    console.log('userEnterRoom')
     if (clientCaller.username === null) {
       clientCaller = {username, socketID: socket.id}
       console.log('set clientCaller', clientCaller, socket.id)
@@ -38,7 +39,7 @@ const streamPeers = (socket: Socket, io: Server) => {
   })
 
   socket.on('videoChatOffer', ({sdp}) => {
-    console.log('offer::', socket.id)
+    console.log('videoChatOffer::', socket.id)
     console.log(`offer - sending getVideoChatOffer to ${clientCallee.username}`)
     
     if (socket.id === clientCaller.socketID) {
@@ -47,7 +48,7 @@ const streamPeers = (socket: Socket, io: Server) => {
   })
 
   socket.on('videoChatAnswer', ({sdp}) => {
-    console.log('answer::', socket.id)
+    console.log('videoChatAnswer::', socket.id)
     console.log(`answer - sending getVideoChatanswer to ${clientCaller.username}`)
     
     io.to(clientCaller.socketID!).emit('getVideoChatAnswer', sdp)
@@ -55,6 +56,7 @@ const streamPeers = (socket: Socket, io: Server) => {
 
 
   socket.on('candidate', ({candidate}) => {
+    console.log('candidate')
     console.log(`ice candidate from ${socket.id}`)
     
     if (socket.id === clientCaller.socketID) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -81,14 +81,14 @@ const App: React.FC = () => {
     navigate(`/p-room/${roomData.roomId}`)
   }, [dispatch, navigate])
 
-  const handleStartVideoInvite = useCallback(peerId => {
+  const handleStartVideoInvite = useCallback(() => {
     console.log('invitation received')
     const modalData = {
       modalContent: 'Start video chat?',
       confirmBtnText: 'Accept',
       declineBtnText: 'Decline',
       isActive: true,
-      peerId: peerId,
+      peerId: null,
       socketEvent: 'video request accepted'
     }
     dispatch(setModal(modalData))

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,7 +77,7 @@ const App: React.FC = () => {
 
   const handleEnterChat = useCallback((roomData: RoomData) => {
     dispatch(resetNotification())
-    dispatch(setRoom({ roomId: roomData.roomId, users: roomData.users}))
+    dispatch(setRoom({ roomId: roomData.roomId, users: roomData.users, isVideoOn: false}))
     navigate(`/p-room/${roomData.roomId}`)
   }, [dispatch, navigate])
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -81,6 +81,19 @@ const App: React.FC = () => {
     navigate(`/p-room/${roomData.roomId}`)
   }, [dispatch, navigate])
 
+  const handleStartVideoInvite = useCallback(peerId => {
+    console.log('invitation received')
+    const modalData = {
+      modalContent: 'Start video chat?',
+      confirmBtnText: 'Accept',
+      declineBtnText: 'Decline',
+      isActive: true,
+      peerId: peerId,
+      socketEvent: 'video request accepted'
+    }
+    dispatch(setModal(modalData))
+  }, [dispatch])
+
   const handleCloseChatRoom = useCallback(() => {
     navigate('/')
     dispatch(resetRoom())
@@ -109,6 +122,7 @@ const App: React.FC = () => {
     socket.on('invite requested', handleInviteRequested)
     socket.on('invite declined', handleInviteDeclined)
     socket.on('enter chat room', handleEnterChat)
+    socket.on('start video invite', handleStartVideoInvite)
     socket.on('close chat room', handleCloseChatRoom)
 
     return () => {
@@ -117,6 +131,7 @@ const App: React.FC = () => {
       socket.off('invite requested', handleInviteRequested)
       socket.off('invite declined', handleInviteDeclined)
       socket.off('enter chat room', handleEnterChat)
+      socket.off('start video invite', handleStartVideoInvite)
       socket.off('closeChatRoom', handleCloseChatRoom)
     }
   }, 
@@ -126,6 +141,7 @@ const App: React.FC = () => {
   handleInviteRequested,
   handleInviteDeclined,
   handleEnterChat,
+  handleStartVideoInvite,
   handleCloseChatRoom])
  
   return (

--- a/frontend/src/app/features/roomSlice.ts
+++ b/frontend/src/app/features/roomSlice.ts
@@ -4,6 +4,7 @@ import { Room } from './types'
 const initialState: Room = {
   roomId: '',
   users: [],
+  isVideoOn: false
 }
 
 export const roomSlice = createSlice({
@@ -14,13 +15,17 @@ export const roomSlice = createSlice({
       state.roomId = action.payload.roomId
       state.users = state.users.concat(action.payload.users)
     },
+    setVideoState: (state, action: PayloadAction<boolean>) => {
+      state.isVideoOn = action.payload
+    },
     resetRoom: (state) => {
       state.roomId = ''
       state.users = []
+      state.isVideoOn = false
     }
   }
 })
 
-export const { setRoom, resetRoom } = roomSlice.actions
+export const { setRoom, resetRoom, setVideoState } = roomSlice.actions
 
 export default roomSlice.reducer

--- a/frontend/src/app/features/types.ts
+++ b/frontend/src/app/features/types.ts
@@ -26,4 +26,5 @@ export interface Notification {
 export interface Room {
   roomId: string;
   users: string[];
+  isVideoOn: boolean;
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Header from "./Header";
 import Navbar from "./Navbar";
+import Modal from "./Modal";
 
 const Layout: React.FC = ({children}) => {
   return (
@@ -8,6 +9,7 @@ const Layout: React.FC = ({children}) => {
       <Navbar />
       <Header />
       {children}
+      <Modal />
     </div>
   )
 }

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -4,6 +4,7 @@ import { User } from '../app/features/types'
 import { useAppSelector, useAppDispatch } from '../app/hooks';
 import { SocketContext } from '../context/socket';
 import { setNotification } from '../app/features/notificationSlice';
+import { setVideoState } from '../app/features/roomSlice';
 
 const ActionModal: React.FC = () => {
   const socket = useContext(SocketContext)
@@ -18,7 +19,6 @@ const ActionModal: React.FC = () => {
       // When user declines invite to chat, send server event that invite was declined
       socket.emit('decline invite', modalData.peerId)
     }
-
     dispatch(resetModal())
   }
 
@@ -41,6 +41,7 @@ const ActionModal: React.FC = () => {
 
     if (modalData.socketEvent === 'video request accepted') {
       console.log('send invite request accepted')
+      dispatch(setVideoState(true))
       socket.emit(modalData.socketEvent)
     }
     

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -40,7 +40,8 @@ const ActionModal: React.FC = () => {
     }
 
     if (modalData.socketEvent === 'video request accepted') {
-      socket.emit(modalData.socketEvent, modalData.peerId)
+      console.log('send invite request accepted')
+      socket.emit(modalData.socketEvent)
     }
     
     dispatch(resetModal())

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -25,7 +25,7 @@ const ActionModal: React.FC = () => {
   const handleAcceptandCloseModal = () => {
     if (modalData.socketEvent === 'invite private chat') {
       const notificationData = {
-        notificationContent: `Wating for a response from ${peerUsername}`,
+        notificationContent: `Waiting for a response from ${peerUsername}`,
         notificationType: 'is-warning',
         isLoading: true,
         isActive: true,
@@ -37,6 +37,10 @@ const ActionModal: React.FC = () => {
     // When user accepts/confirms, the send server event that invite was accepted
     if (modalData.socketEvent === 'invite requested') {
       socket.emit('invite accepted', modalData.peerId)
+    }
+
+    if (modalData.socketEvent === 'video request accepted') {
+      socket.emit(modalData.socketEvent, modalData.peerId)
     }
     
     dispatch(resetModal())

--- a/frontend/src/components/RoomOptions.tsx
+++ b/frontend/src/components/RoomOptions.tsx
@@ -7,14 +7,20 @@ const RoomOptions = () => {
 
   const roomId = useAppSelector(state => state.room.roomId)
 
-  const handleClick = () => {
+  const handleEndClick = () => {
     console.log('end chat')
     socket.emit('end chat', roomId)
   }
 
+  const handleVideoClick = () => {
+    console.log('start video')
+    socket.emit('start video request')
+  }
+
   return (
     <div className="mt-4 is-flex is-flex-direction-row is-justify-content-center">
-      <button className="button is-danger" onClick={handleClick}>End Chat</button>
+      <button className="button is-danger mr-1" onClick={handleEndClick}>End Chat</button>
+      <button className="button is-link ml-1" onClick={handleVideoClick}>Start Video</button>
     </div>
   )
 }

--- a/frontend/src/components/RoomOptions.tsx
+++ b/frontend/src/components/RoomOptions.tsx
@@ -8,8 +8,6 @@ const RoomOptions = () => {
   const dispatch = useAppDispatch()
 
   const room = useAppSelector(state => state.room)
-  // const roomId = useAppSelector(state => state.room.roomId)
-  // const users = useAppSelector(state => state.room.users)
 
   const handleEndClick = () => {
     console.log('end chat')

--- a/frontend/src/components/RoomOptions.tsx
+++ b/frontend/src/components/RoomOptions.tsx
@@ -1,11 +1,12 @@
 import React, { useContext } from "react";
-import { useAppSelector } from "../app/hooks";
+import { useAppSelector } from '../app/hooks';
 import { SocketContext } from "../context/socket";
 
 const RoomOptions = () => {
   const socket = useContext(SocketContext)
 
   const roomId = useAppSelector(state => state.room.roomId)
+  const users = useAppSelector(state => state.room.users)
 
   const handleEndClick = () => {
     console.log('end chat')
@@ -14,7 +15,7 @@ const RoomOptions = () => {
 
   const handleVideoClick = () => {
     console.log('start video')
-    socket.emit('start video request')
+    socket.emit('start video request', users)
   }
 
   return (

--- a/frontend/src/components/RoomOptions.tsx
+++ b/frontend/src/components/RoomOptions.tsx
@@ -1,27 +1,32 @@
 import React, { useContext } from "react";
-import { useAppSelector } from '../app/hooks';
+import { setVideoState } from "../app/features/roomSlice";
+import { useAppSelector, useAppDispatch } from '../app/hooks';
 import { SocketContext } from "../context/socket";
 
 const RoomOptions = () => {
   const socket = useContext(SocketContext)
+  const dispatch = useAppDispatch()
 
-  const roomId = useAppSelector(state => state.room.roomId)
-  const users = useAppSelector(state => state.room.users)
+  const room = useAppSelector(state => state.room)
+  // const roomId = useAppSelector(state => state.room.roomId)
+  // const users = useAppSelector(state => state.room.users)
 
   const handleEndClick = () => {
     console.log('end chat')
-    socket.emit('end chat', roomId)
+    socket.emit('end chat', room.roomId)
   }
 
-  const handleVideoClick = () => {
+  const handleStartVideoClick = () => {
     console.log('start video')
-    socket.emit('start video request', users)
+    dispatch(setVideoState(true))
+    socket.emit('start video request', room.users)
   }
 
   return (
     <div className="mt-4 is-flex is-flex-direction-row is-justify-content-center">
       <button className="button is-danger mr-1" onClick={handleEndClick}>End Chat</button>
-      <button className="button is-link ml-1" onClick={handleVideoClick}>Start Video</button>
+      {!room.isVideoOn && <button className="button is-link ml-1" onClick={handleStartVideoClick}>Start Video</button>}
+      
     </div>
   )
 }

--- a/frontend/src/components/VideoDisplay.tsx
+++ b/frontend/src/components/VideoDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useRef } from "react";
+import React, { useEffect, useContext, useRef } from "react";
 import { SocketContext } from "../context/socket";
 
 const VideoDisplay = () => {
@@ -15,26 +15,29 @@ const VideoDisplay = () => {
     video: { width: 300, height: 150 }
   }
 
-  socket.on('userWaiting', message => {
-    console.log('message', message)
-  })
+  useEffect(() => {
+    socket.on('userWaiting', message => {
+      console.log('message', message)
+    })
 
-  socket.on('roomReady', readyMessage => {
-    console.log('message', readyMessage)
-    startVideoChat();
-  })
+    socket.on('roomReady', readyMessage => {
+      console.log('message', readyMessage)
+      startVideoChat();
+    })
 
-  socket.on('getVideoChatOffer', (sdp: RTCSessionDescription) => {
-    handleVideoChatOffer(sdp);
-  })
+    socket.on('getVideoChatOffer', (sdp: RTCSessionDescription) => {
+      handleVideoChatOffer(sdp);
+    })
 
-  socket.on('getVideoChatAnswer', (sdp: RTCSessionDescription) => {
-    handleVideoChatAnswer(sdp)
-  })
+    socket.on('getVideoChatAnswer', (sdp: RTCSessionDescription) => {
+      handleVideoChatAnswer(sdp)
+    })
 
-  socket.on('getCandidate', (candidate: RTCIceCandidate) => {
-    handleNewICECandidate(candidate)
-  })
+    socket.on('getCandidate', (candidate: RTCIceCandidate) => {
+      handleNewICECandidate(candidate)
+    })
+  }, [socket, startVideoChat, handleVideoChatOffer, handleVideoChatAnswer, handleNewICECandidate])
+  
 
   async function createPeerConnection() {   
     myPeerConnection = new RTCPeerConnection() // For peers to connect from different networks, need to specify TURN or STUN servers

--- a/frontend/src/components/VideoDisplay.tsx
+++ b/frontend/src/components/VideoDisplay.tsx
@@ -204,12 +204,12 @@ const VideoDisplay = () => {
 
   
   useEffect(() => {
-    socket.on('userWaiting', message => {
-      console.log('message', message)
-    })
+    // socket.on('userWaiting', message => {
+    //   console.log('message', message)
+    // })
 
-    socket.on('roomReady', readyMessage => {
-      console.log('message', readyMessage)
+    socket.on('video ready', () => {
+      console.log('starting video chat on client')
       startVideoChat()
     })
 

--- a/frontend/src/components/VideoDisplay.tsx
+++ b/frontend/src/components/VideoDisplay.tsx
@@ -10,9 +10,6 @@ const VideoDisplay = () => {
   const streamRef = useRef<HTMLVideoElement|null>(null);
   const remoteStreamRef = useRef<HTMLVideoElement|null>(null);
 
-  // let myPeerConnection: RTCPeerConnection | null = null   // RTCPeerConnection
-  // let myPeerConnection: RTCPeerConnection | null   // RTCPeerConnection
-
   const mediaConstraints = useMemo(() => {
     return {audio: true,
     video: { width: 300, height: 150 }
@@ -35,7 +32,7 @@ const VideoDisplay = () => {
         await myPeerConnectionRef.current.setLocalDescription(offer)
 
         // send offer to remote peer
-        socket.emit('videoChatOffer', {sdp: myPeerConnectionRef.current.localDescription})
+        socket.emit('video offer', {sdp: myPeerConnectionRef.current.localDescription})
       } catch (err) {
         console.log('error in handleNegotiationNeededEvent: ', err)
       }
@@ -160,7 +157,7 @@ const VideoDisplay = () => {
             offerToReceiveAudio: true,
           })
           await myPeerConnectionRef.current.setLocalDescription(new RTCSessionDescription(answer))
-          socket.emit('videoChatAnswer', {sdp: myPeerConnectionRef.current.localDescription})
+          socket.emit('video answer', {sdp: myPeerConnectionRef.current.localDescription})
         } catch (err) {
           console.log('error in handleVideoChatOffer - sending answer', err)
         }
@@ -204,24 +201,19 @@ const VideoDisplay = () => {
 
   
   useEffect(() => {
-    // socket.on('userWaiting', message => {
-    //   console.log('message', message)
-    // })
-
     socket.on('video ready', () => {
-      console.log('starting video chat on client')
       startVideoChat()
     })
 
-    socket.on('getVideoChatOffer', (sdp: RTCSessionDescription) => {
+    socket.on('get video offer', (sdp: RTCSessionDescription) => {
       handleVideoChatOffer(sdp);
     })
 
-    socket.on('getVideoChatAnswer', (sdp: RTCSessionDescription) => {
+    socket.on('get video answer', (sdp: RTCSessionDescription) => {
       handleVideoChatAnswer(sdp)
     })
   
-    socket.on('getCandidate', (candidate: RTCIceCandidate) => {
+    socket.on('get candidate', (candidate: RTCIceCandidate) => {
       handleNewICECandidate(candidate)
     })
 
@@ -237,7 +229,7 @@ const VideoDisplay = () => {
     console.log('closing peer connection') 
 
     if (myPeerConnectionRef.current) {
-      console.log('starting to cleear peer methods')
+      console.log('starting to clear peer methods')
       myPeerConnectionRef.current.ontrack = null;
       // myPeerConnection.onremovetrack = null;
       // myPeerConnection.onremovestream = null;

--- a/frontend/src/components/VideoDisplay.tsx
+++ b/frontend/src/components/VideoDisplay.tsx
@@ -1,15 +1,17 @@
-import React, { useEffect, useContext, useRef, useCallback, useState, useMemo } from "react";
+import React, { useEffect, useContext, useRef, useCallback, useMemo } from "react";
 import { SocketContext } from "../context/socket";
 
 const VideoDisplay = () => {
   const socket = useContext(SocketContext);
 
-  const [webcamStream, setWebcamStream] = useState<MediaStream|null>(null)
+  const webcamStreamRef = useRef<MediaStream|null>(null)
+  const myPeerConnectionRef = useRef<RTCPeerConnection|null>(null)
 
   const streamRef = useRef<HTMLVideoElement|null>(null);
   const remoteStreamRef = useRef<HTMLVideoElement|null>(null);
 
-  let myPeerConnection: RTCPeerConnection | null = null;    // RTCPeerConnection
+  // let myPeerConnection: RTCPeerConnection | null = null   // RTCPeerConnection
+  // let myPeerConnection: RTCPeerConnection | null   // RTCPeerConnection
 
   const mediaConstraints = useMemo(() => {
     return {audio: true,
@@ -17,28 +19,47 @@ const VideoDisplay = () => {
     }
   }, [])
 
+  const createPeerConnection = useCallback( async () => {
+    myPeerConnectionRef.current = new RTCPeerConnection() // For peers to connect from different networks, need to specify TURN or STUN servers
+    
+    // Set up event handlers for the ICE negotiation process.
+    myPeerConnectionRef.current.onicecandidate = handleICECandidateEvent;
+    myPeerConnectionRef.current.oniceconnectionstatechange = handleICEConnectionStateChangeEvent;
+    myPeerConnectionRef.current.onicegatheringstatechange = handleICEGatheringStateChangeEvent;
+    myPeerConnectionRef.current.onsignalingstatechange = handleSignalingStateChangeEvent;
+    myPeerConnectionRef.current.onnegotiationneeded = handleNegotiationNeededEvent;
+    myPeerConnectionRef.current.ontrack = handleTrackEvent;
+  }, 
+  [
+    handleICECandidateEvent,
+    handleICEConnectionStateChangeEvent,
+    handleICEGatheringStateChangeEvent,
+    handleSignalingStateChangeEvent,
+    handleNegotiationNeededEvent,
+  ])
+
   const startVideoChat = useCallback( async () => {
-    if (!myPeerConnection) {
+    if (!myPeerConnectionRef.current) {
       createPeerConnection();
     }
 
     // Get access to webcam stream and display it in local stream
     try {
-      const localWebcamStream = await navigator.mediaDevices.getUserMedia(mediaConstraints)
-      setWebcamStream(localWebcamStream)
-      webcamStream?.getTracks().forEach((track: MediaStreamTrack) => {
-        if (myPeerConnection) {
-          myPeerConnection.addTrack(track, webcamStream)
+      webcamStreamRef.current = await navigator.mediaDevices.getUserMedia(mediaConstraints)
+      webcamStreamRef.current?.getTracks().forEach((track: MediaStreamTrack) => {
+        if (myPeerConnectionRef.current) {
+          myPeerConnectionRef.current.addTrack(track, webcamStreamRef.current!)
         }
       })
       if (streamRef.current) {
-        streamRef.current.srcObject = webcamStream;
+        streamRef.current.srcObject = webcamStreamRef.current;
       }
     } catch (err) {
       console.log('error in enterVideoChat - local webcam stream', err)
     }
-  }, [createPeerConnection, mediaConstraints, myPeerConnection, webcamStream])
+  }, [createPeerConnection, mediaConstraints])
 
+  
   useEffect(() => {
     socket.on('userWaiting', message => {
       console.log('message', message)
@@ -49,31 +70,32 @@ const VideoDisplay = () => {
       startVideoChat()
     })
 
-    socket.on('getVideoChatOffer', (sdp: RTCSessionDescription) => {
-      handleVideoChatOffer(sdp);
-    })
-
-    socket.on('getVideoChatAnswer', (sdp: RTCSessionDescription) => {
-      handleVideoChatAnswer(sdp)
-    })
-
-    socket.on('getCandidate', (candidate: RTCIceCandidate) => {
-      handleNewICECandidate(candidate)
-    })
   }, [socket, startVideoChat, handleVideoChatOffer, handleVideoChatAnswer, handleNewICECandidate])
   
 
-  async function createPeerConnection() {   
-    myPeerConnection = new RTCPeerConnection() // For peers to connect from different networks, need to specify TURN or STUN servers
+  socket.on('getVideoChatOffer', (sdp: RTCSessionDescription) => {
+    handleVideoChatOffer(sdp);
+  })
 
-    // Set up event handlers for the ICE negotiation process.
-    myPeerConnection.onicecandidate = handleICECandidateEvent;
-    myPeerConnection.oniceconnectionstatechange = handleICEConnectionStateChangeEvent;
-    myPeerConnection.onicegatheringstatechange = handleICEGatheringStateChangeEvent;
-    myPeerConnection.onsignalingstatechange = handleSignalingStateChangeEvent;
-    myPeerConnection.onnegotiationneeded = handleNegotiationNeededEvent;
-    myPeerConnection.ontrack = handleTrackEvent;
-  }
+  socket.on('getVideoChatAnswer', (sdp: RTCSessionDescription) => {
+    handleVideoChatAnswer(sdp)
+  })
+
+  socket.on('getCandidate', (candidate: RTCIceCandidate) => {
+    handleNewICECandidate(candidate)
+  })
+
+  // async function createPeerConnection() {   
+  //   myPeerConnection = new RTCPeerConnection() // For peers to connect from different networks, need to specify TURN or STUN servers
+
+  //   // Set up event handlers for the ICE negotiation process.
+  //   myPeerConnection.onicecandidate = handleICECandidateEvent;
+  //   myPeerConnection.oniceconnectionstatechange = handleICEConnectionStateChangeEvent;
+  //   myPeerConnection.onicegatheringstatechange = handleICEGatheringStateChangeEvent;
+  //   myPeerConnection.onsignalingstatechange = handleSignalingStateChangeEvent;
+  //   myPeerConnection.onnegotiationneeded = handleNegotiationNeededEvent;
+  //   myPeerConnection.ontrack = handleTrackEvent;
+  // }
 
   async function handleNegotiationNeededEvent() {
     if (myPeerConnection) {

--- a/frontend/src/components/VideoDisplay.tsx
+++ b/frontend/src/components/VideoDisplay.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const VideoDisplay = () => {
+
+  return (
+    <div>
+      <p>Video placeholder</p>
+    </div>
+  )
+}
+
+export default VideoDisplay;

--- a/frontend/src/components/VideoDisplay.tsx
+++ b/frontend/src/components/VideoDisplay.tsx
@@ -1,11 +1,273 @@
-import React from "react";
+import React, { useContext, useRef } from "react";
+import { SocketContext } from "../context/socket";
 
 const VideoDisplay = () => {
+  const socket = useContext(SocketContext);
+
+  const streamRef = useRef<HTMLVideoElement|null>(null);
+  const remoteStreamRef = useRef<HTMLVideoElement|null>(null);
+
+  let myPeerConnection: RTCPeerConnection | null = null;    // RTCPeerConnection
+  let webcamStream: MediaStream;        // MediaStream from webcam
+
+  const mediaConstraints = {
+    audio: true,
+    video: { width: 300, height: 150 }
+  }
+
+  socket.on('userWaiting', message => {
+    console.log('message', message)
+  })
+
+  socket.on('roomReady', readyMessage => {
+    console.log('message', readyMessage)
+    startVideoChat();
+  })
+
+  socket.on('getVideoChatOffer', (sdp: RTCSessionDescription) => {
+    handleVideoChatOffer(sdp);
+  })
+
+  socket.on('getVideoChatAnswer', (sdp: RTCSessionDescription) => {
+    handleVideoChatAnswer(sdp)
+  })
+
+  socket.on('getCandidate', (candidate: RTCIceCandidate) => {
+    handleNewICECandidate(candidate)
+  })
+
+  async function createPeerConnection() {   
+    myPeerConnection = new RTCPeerConnection() // For peers to connect from different networks, need to specify TURN or STUN servers
+
+    // Set up event handlers for the ICE negotiation process.
+    myPeerConnection.onicecandidate = handleICECandidateEvent;
+    myPeerConnection.oniceconnectionstatechange = handleICEConnectionStateChangeEvent;
+    myPeerConnection.onicegatheringstatechange = handleICEGatheringStateChangeEvent;
+    myPeerConnection.onsignalingstatechange = handleSignalingStateChangeEvent;
+    myPeerConnection.onnegotiationneeded = handleNegotiationNeededEvent;
+    myPeerConnection.ontrack = handleTrackEvent;
+  }
+
+  async function handleNegotiationNeededEvent() {
+    if (myPeerConnection) {
+      try {
+        const offer = await myPeerConnection.createOffer({
+          offerToReceiveAudio: true, 
+          offerToReceiveVideo: true
+        });
+      
+        if (myPeerConnection.signalingState !== 'stable') {
+          console.log('connection is not stable yet...')
+          return;
+        }
+
+        await myPeerConnection.setLocalDescription(offer)
+
+        // send offer to remote peer
+        socket.emit('videoChatOffer', {sdp: myPeerConnection.localDescription})
+      } catch (err) {
+        console.log('error in handleNegotiationNeededEvent: ', err)
+      }
+    } 
+  }
+
+  async function startVideoChat() {
+    if (!myPeerConnection) {
+      createPeerConnection();
+    }
+
+    // Get access to webcam stream and display it in local stream
+    try {
+      webcamStream = await navigator.mediaDevices.getUserMedia(mediaConstraints)
+      webcamStream.getTracks().forEach((track: MediaStreamTrack) => {
+        if (myPeerConnection) {
+          myPeerConnection.addTrack(track, webcamStream)
+        }
+      })
+      if (streamRef.current) {
+        streamRef.current.srcObject = webcamStream;
+      }
+    } catch (err) {
+      console.log('error in enterVideoChat - local webcam stream', err)
+    }
+  }
+
+  async function handleVideoChatOffer(sdp: RTCSessionDescription) {
+    // If not already connect, create RTCPeerConncetion  
+    if (!myPeerConnection) {
+      createPeerConnection()
+    } 
+
+    if (myPeerConnection) {
+      // Set up remote description to the received SDP offer
+      const desc = new RTCSessionDescription(sdp)
+      try {
+        if (myPeerConnection.signalingState !== 'stable') {
+          console.log('handle video chat offer not stable')
+          await Promise.all([
+            myPeerConnection.setLocalDescription({type: 'rollback'}),
+            myPeerConnection.setRemoteDescription(sdp)
+          ]);
+          return;
+        } else {
+          await myPeerConnection.setRemoteDescription(desc)
+        }
+
+        // Get webcam stream
+        if (!webcamStream) {
+          // Get access to webcam stream and display it in local stream
+          try {
+            webcamStream = await navigator.mediaDevices.getUserMedia(mediaConstraints)
+            if (streamRef.current) {
+              streamRef.current.srcObject = webcamStream;
+            }
+          } catch (err) {
+            console.log('error in handleVideoChatOffer - local webcam stream', err)
+          }
+
+          // Add tracks from stream to the RTCPeerConnection
+          if (webcamStream) {
+            try {
+              webcamStream.getTracks().forEach((track: MediaStreamTrack) => {
+                if (myPeerConnection) {
+                  myPeerConnection.addTrack(track, webcamStream)
+                }
+              })
+            } catch (err) {
+              console.log('error in handleVideoChatOffer - webcam stream add tracks', err)
+            }
+          }
+        }
+
+        // Send answer to caller
+        try {
+          const answer = await myPeerConnection.createAnswer({
+            offerToReceiveVideo: true,
+            offerToReceiveAudio: true,
+          })
+          await myPeerConnection.setLocalDescription(new RTCSessionDescription(answer))
+          socket.emit('videoChatAnswer', {sdp: myPeerConnection.localDescription})
+        } catch (err) {
+          console.log('error in handleVideoChatOffer - sending answer', err)
+        }
+      } catch (err) {
+        console.log('error in handleVideoChatOffer')
+      }
+    } 
+  }
+
+  async function handleVideoChatAnswer(sdp: RTCSessionDescription) {
+    if (myPeerConnection) {
+      try {
+        const desc = new RTCSessionDescription(sdp);
+        await myPeerConnection.setRemoteDescription(desc)
+      } catch (err) {
+        console.log('error in handleVideoChatAnswer', err)
+      } 
+    }
+     
+  }
+
+  function handleICECandidateEvent(event: RTCPeerConnectionIceEvent) {
+    if (event.candidate) {
+      socket.emit('candidate', {candidate: event.candidate})
+    }
+  }
+
+  async function handleNewICECandidate(candidate: RTCIceCandidate) {
+    if (myPeerConnection) {
+      candidate = new RTCIceCandidate(candidate)
+      try {
+        await myPeerConnection.addIceCandidate(candidate)
+      } catch (err) {
+        console.log('error in handleNewICECandidate', err)
+      } 
+    } 
+  }
+
+  function handleICEGatheringStateChangeEvent(event: any) {
+    if (myPeerConnection) {
+      console.log(`ice gathering state changed to: ${myPeerConnection.iceGatheringState}`)
+    } 
+  }
+
+  function handleICEConnectionStateChangeEvent(event: any) {
+    if (myPeerConnection) {
+      switch(myPeerConnection.iceConnectionState) {
+        case 'closed':
+        case 'failed':
+        case 'disconnected':
+          closeVideoCall();
+          break;
+      }
+    }
+    
+  }
+
+  function handleTrackEvent(event: RTCTrackEvent) {
+    if (remoteStreamRef.current) {
+      remoteStreamRef.current.srcObject = event.streams[0];
+    }
+  }
+
+  function closeVideoCall() {
+    console.log('closing peer connection') 
+
+    if (myPeerConnection) {
+      console.log('starting to cleear peer methods')
+      myPeerConnection.ontrack = null;
+      // myPeerConnection.onremovetrack = null;
+      // myPeerConnection.onremovestream = null;
+      myPeerConnection.onicecandidate = null;
+      myPeerConnection.oniceconnectionstatechange = null;
+      myPeerConnection.onsignalingstatechange = null;
+      myPeerConnection.onicegatheringstatechange = null;
+      myPeerConnection.onnegotiationneeded = null;
+
+      // myPeerConnection.getTransceivers().forEach(transceiver => {
+      //   transceiver.stop();
+      // });
+
+      myPeerConnection.close();
+      myPeerConnection = null;
+      console.log('closed peer connection')
+    }
+    
+
+    if (webcamStream && streamRef.current) {
+        streamRef.current.pause();
+        webcamStream.getTracks().forEach(track => {
+          track.stop();
+        })
+        streamRef.current.srcObject = null
+      }
+
+    if (remoteStreamRef.current) {
+      remoteStreamRef.current.pause();
+      remoteStreamRef.current.srcObject = null 
+    }
+  }
+
+  function handleSignalingStateChangeEvent(event: any) {
+    if (myPeerConnection) {
+      switch (myPeerConnection.signalingState) {
+        case 'closed':
+          closeVideoCall();
+          break;
+      }
+    }
+    
+  }
+
+  // function endVideoChat () {
+  //   closeVideoCall();
+  //   resetUsername();
+  // }
 
   return (
     <div className="is-flex is-flex-direction-row">
-      <video id="videoStream" autoPlay>There is a problem playing the video.</video>
-      <video id="remoteVideoStream" autoPlay>There is a problem playing the video.</video>
+      <video ref={el => { streamRef.current = el}} id="videoStream" autoPlay>There is a problem playing the video.</video>
+      <video ref={el => { remoteStreamRef.current = el}} id="remoteVideoStream" autoPlay>There is a problem playing the video.</video>
     </div>
   )
 }

--- a/frontend/src/components/VideoDisplay.tsx
+++ b/frontend/src/components/VideoDisplay.tsx
@@ -3,8 +3,9 @@ import React from "react";
 const VideoDisplay = () => {
 
   return (
-    <div>
-      <p>Video placeholder</p>
+    <div className="is-flex is-flex-direction-row">
+      <video id="videoStream" autoPlay>There is a problem playing the video.</video>
+      <video id="remoteVideoStream" autoPlay>There is a problem playing the video.</video>
     </div>
   )
 }

--- a/frontend/src/components/testComponents/testVideoGrid.tsx
+++ b/frontend/src/components/testComponents/testVideoGrid.tsx
@@ -20,27 +20,31 @@ const TestVideoGrid: React.FC<TestVideoGridProps> = memo(({resetUsername}) => {
   }
 
   socket.on('userWaiting', message => {
-    console.log('message', message)
+    console.log('userWaiting - message', message)
   })
 
   socket.on('roomReady', readyMessage => {
-    console.log('message', readyMessage)
+    console.log('roomReady - message', readyMessage)
     startVideoChat();
   })
 
   socket.on('getVideoChatOffer', (sdp: RTCSessionDescription) => {
+    console.log('getVideoChatOffer')
     handleVideoChatOffer(sdp);
   })
 
   socket.on('getVideoChatAnswer', (sdp: RTCSessionDescription) => {
+    console.log('getVideoChatAnswer')
     handleVideoChatAnswer(sdp)
   })
 
   socket.on('getCandidate', (candidate: RTCIceCandidate) => {
+    console.log('getCandidate')
     handleNewICECandidate(candidate)
   })
 
   async function createPeerConnection() {   
+    console.log('createPeerConnection')
     myPeerConnection = new RTCPeerConnection() // For peers to connect from different networks, need to specify TURN or STUN servers
 
     // Set up event handlers for the ICE negotiation process.
@@ -53,6 +57,7 @@ const TestVideoGrid: React.FC<TestVideoGridProps> = memo(({resetUsername}) => {
   }
 
   async function handleNegotiationNeededEvent() {
+    console.log('handleNegotiationNeededEvent')
     if (myPeerConnection) {
       try {
         const offer = await myPeerConnection.createOffer({
@@ -77,6 +82,8 @@ const TestVideoGrid: React.FC<TestVideoGridProps> = memo(({resetUsername}) => {
   }
 
   async function startVideoChat() {
+    console.log('startVideoChat')
+
     if (!myPeerConnection) {
       createPeerConnection();
     }
@@ -98,6 +105,8 @@ const TestVideoGrid: React.FC<TestVideoGridProps> = memo(({resetUsername}) => {
   }
 
   async function handleVideoChatOffer(sdp: RTCSessionDescription) {
+    console.log('handleVideoChatOffer')
+    
     // If not already connect, create RTCPeerConncetion  
     if (!myPeerConnection) {
       createPeerConnection()
@@ -162,6 +171,8 @@ const TestVideoGrid: React.FC<TestVideoGridProps> = memo(({resetUsername}) => {
   }
 
   async function handleVideoChatAnswer(sdp: RTCSessionDescription) {
+    console.log('handleVideoChatAnswer')
+    
     if (myPeerConnection) {
       try {
         const desc = new RTCSessionDescription(sdp);
@@ -174,12 +185,16 @@ const TestVideoGrid: React.FC<TestVideoGridProps> = memo(({resetUsername}) => {
   }
 
   function handleICECandidateEvent(event: RTCPeerConnectionIceEvent) {
+    console.log('handleICECandidateEvent')
+    
     if (event.candidate) {
       socket.emit('candidate', {candidate: event.candidate})
     }
   }
 
   async function handleNewICECandidate(candidate: RTCIceCandidate) {
+    console.log('handleNewICECandidate')
+    
     if (myPeerConnection) {
       candidate = new RTCIceCandidate(candidate)
       try {
@@ -191,12 +206,16 @@ const TestVideoGrid: React.FC<TestVideoGridProps> = memo(({resetUsername}) => {
   }
 
   function handleICEGatheringStateChangeEvent(event: any) {
+    console.log('handleICEGatheringStateChangeEvent')
+    
     if (myPeerConnection) {
       console.log(`ice gathering state changed to: ${myPeerConnection.iceGatheringState}`)
     } 
   }
 
   function handleICEConnectionStateChangeEvent(event: any) {
+    console.log('handleICEConnectionStateChangeEvent')
+    
     if (myPeerConnection) {
       switch(myPeerConnection.iceConnectionState) {
         case 'closed':
@@ -210,6 +229,8 @@ const TestVideoGrid: React.FC<TestVideoGridProps> = memo(({resetUsername}) => {
   }
 
   function handleTrackEvent(event: RTCTrackEvent) {
+    console.log('handleTrackEvent')
+    
     if (remoteStreamRef.current) {
       remoteStreamRef.current.srcObject = event.streams[0];
     }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import ActiveUsers from '../components/ActiveUsers';
 import Layout from '../components/Layout';
 import NewUserForm from '../components/NewUserForm';
 import { useAppSelector } from '../app/hooks';
-import Modal from '../components/Modal';
+// import Modal from '../components/Modal';
 import Notification from '../components/Notification';
 
 const Home = () => {
@@ -23,7 +23,7 @@ const Home = () => {
       :
         <ActiveUsers />
       } 
-      <Modal />
+      {/* <Modal /> */}
     </Layout>
   )
 }

--- a/frontend/src/pages/PrivateRoom.tsx
+++ b/frontend/src/pages/PrivateRoom.tsx
@@ -37,7 +37,7 @@ const PrivateRoom = () => {
         ? 
           <div className="is-flex is-flex-direction-column is-flex-grow-1">
             <RoomOptions />
-            <VideoDisplay />
+            {room.isVideoOn && <VideoDisplay />}    
             <Chat />
           </div>
         : <p>No access</p>}

--- a/frontend/src/pages/PrivateRoom.tsx
+++ b/frontend/src/pages/PrivateRoom.tsx
@@ -6,6 +6,7 @@ import Chat from '../components/Chat';
 import RoomOptions from '../components/RoomOptions';
 import { Navigate } from 'react-router-dom';
 import { SocketContext } from '../context/socket';
+import VideoDisplay from '../components/VideoDisplay';
 
 const PrivateRoom = () => {
   const socket = useContext(SocketContext)
@@ -36,6 +37,7 @@ const PrivateRoom = () => {
         ? 
           <div className="is-flex is-flex-direction-column is-flex-grow-1">
             <RoomOptions />
+            <VideoDisplay />
             <Chat />
           </div>
         : <p>No access</p>}


### PR DESCRIPTION
### Description
This PR adds the feature for users in a private chat room to start a two way live video chat. When one of the users clicks the button `Start Video`, the other user will receive a request to accept the invitation to start a video chat. After the user accepts, the connection between the two users is established with [RTC Peer Connection](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection) and the webcam feeds are accessed with the [MediaStream API](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream).

### Type
- [x] New feature
- [ ] Refactoring
- [ ] Bug-fix
- [ ] DevOps
- [ ] Testing

### Demo

https://user-images.githubusercontent.com/54559570/149162186-01693c7d-dd9c-4a11-bdf2-244aeb2fb736.mp4

### Testing
- Clone this branch and install dependencies
- Run the development server `npm run dev`
- Open two Firefox browsers
- Go the page localhost:3000 in each browsers
- Initiate a private chat by clicking `Invite to Chat` in one of the browsers
- Initiate a video chat by clicking `Start Video`  in one of the browsers

Notes:
- May not work with Chrome
- Can work with one or two webcams.  If there is only one webcam, the local and remote feeds will be the same.
