### PR TITLE
Refactor private chat

### DIFF
--- a/backend/src/pubsub/privateChat.ts
+++ b/backend/src/pubsub/privateChat.ts
@@ -13,11 +13,14 @@ const privateChat = (socket: Socket, io: Server) => {
 
   socket.on('invite accepted', (inviterId) => {
     console.log(`${socket.id} accepted chat with ${inviterId}`)
-    const roomId = `${inviterId}-room`
-    const roomData = { roomId: roomId, users: [inviterId , socket.id] }
+    peer1 = inviterId
+    peer2 = socket.id
+    const roomId = `${peer1}-room`
+    const roomData = { roomId: roomId, users: [peer1 , peer2] }
     
-    io.in(socket.id).socketsJoin(roomId)
-    io.in(inviterId).socketsJoin(roomId)
+    
+    io.in(peer2).socketsJoin(roomId)
+    io.in(peer1).socketsJoin(roomId)
 
     io.to(roomId).emit('enter chat room', roomData)
   })
@@ -36,19 +39,6 @@ const privateChat = (socket: Socket, io: Server) => {
     
     io.to(sentMessageData.roomId).emit('receive chat message', messageData);
     console.log('message: ' + messageData.msg);
-  })
-
-  // delete the following event
-  // assign peer1 and peer2 in 'invite accepted' event
-  socket.on('start video request', (users: string[]) => {
-    peer1 = socket.id
-    peer2 = users.find(user => user !== socket.id)!
-    
-    console.log('start video request')
-
-    if (peer2) {
-      io.to(peer2).emit('start video invite')
-    }
   })
 
   socket.on('video request accepted', () => {

--- a/backend/src/pubsub/privateChat.ts
+++ b/backend/src/pubsub/privateChat.ts
@@ -38,6 +38,8 @@ const privateChat = (socket: Socket, io: Server) => {
     console.log('message: ' + messageData.msg);
   })
 
+  // delete the following event
+  // assign peer1 and peer2 in 'invite accepted' event
   socket.on('start video request', (users: string[]) => {
     peer1 = socket.id
     peer2 = users.find(user => user !== socket.id)!

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,18 +3,18 @@ import {
   Routes,
   Route,
 } from "react-router-dom";
-import './styles/app.scss'
 import { useNavigate } from 'react-router-dom';
 import { SocketContext } from './context/socket';
-import TestRoom from './pages/TestRoom';
-import Home from './pages/Home';
-import { User } from './app/features/types';
 import { useAppDispatch, useAppSelector } from './app/hooks';
 import { setNewUser, setId } from './app/features/userSlice';
 import { getAllActiveUsers } from './app/features/activeUsersSlice';
 import { resetRoom, setRoom } from './app/features/roomSlice';
 import { setModal } from './app/features/modalSlice';
 import { setNotification, resetNotification } from './app/features/notificationSlice';
+import './styles/app.scss'
+import { User } from './app/features/types';
+import TestRoom from './pages/TestRoom';
+import Home from './pages/Home';
 import PrivateRoom from './pages/PrivateRoom';
 import { handleSendVideoInvite } from './services/publishers';
 
@@ -80,7 +80,7 @@ const App: React.FC = () => {
 
   const handleEnterChat = useCallback((roomData: RoomData) => {
     dispatch(resetNotification())
-    dispatch(setRoom({ roomId: roomData.roomId, users: roomData.users, isChatVisible: false, messages: [] }))
+    dispatch(setRoom({ roomId: roomData.roomId, users: roomData.users, isTextChatVisible: false, messages: [] }))
     navigate(`/p-room/${roomData.roomId}`)
     if (roomData.users[0] === currentUser) {
       // Start RTC Peer Connection

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -80,7 +80,7 @@ const App: React.FC = () => {
 
   const handleEnterChat = useCallback((roomData: RoomData) => {
     dispatch(resetNotification())
-    dispatch(setRoom({ roomId: roomData.roomId, users: roomData.users }))
+    dispatch(setRoom({ roomId: roomData.roomId, users: roomData.users, isChatVisible: false }))
     navigate(`/p-room/${roomData.roomId}`)
     if (roomData.users[0] === currentUser) {
       // Start RTC Peer Connection

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -78,7 +78,7 @@ const App: React.FC = () => {
 
   const handleEnterChat = useCallback((roomData: RoomData) => {
     dispatch(resetNotification())
-    dispatch(setRoom({ roomId: roomData.roomId, users: roomData.users, isVideoOn: false}))
+    dispatch(setRoom({ roomId: roomData.roomId, users: roomData.users }))
     navigate(`/p-room/${roomData.roomId}`)
   }, [dispatch, navigate])
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -80,7 +80,7 @@ const App: React.FC = () => {
 
   const handleEnterChat = useCallback((roomData: RoomData) => {
     dispatch(resetNotification())
-    dispatch(setRoom({ roomId: roomData.roomId, users: roomData.users, isChatVisible: false }))
+    dispatch(setRoom({ roomId: roomData.roomId, users: roomData.users, isChatVisible: false, messages: [] }))
     navigate(`/p-room/${roomData.roomId}`)
     if (roomData.users[0] === currentUser) {
       // Start RTC Peer Connection

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { resetRoom, setRoom } from './app/features/roomSlice';
 import { setModal } from './app/features/modalSlice';
 import { setNotification, resetNotification } from './app/features/notificationSlice';
 import PrivateRoom from './pages/PrivateRoom';
+import { handleSendVideoInvite } from './services/publishers';
 
 interface RoomData {
   roomId: string;
@@ -80,21 +81,23 @@ const App: React.FC = () => {
     dispatch(resetNotification())
     dispatch(setRoom({ roomId: roomData.roomId, users: roomData.users }))
     navigate(`/p-room/${roomData.roomId}`)
+    // need to make sure that only one user calls handleSendVideoInvite
+    handleSendVideoInvite()
   }, [dispatch, navigate])
 
-  const handleStartVideoInvite = useCallback(() => {
-    console.log('invitation received')
-    const modalData = {
-      modalName: 'start video chat',
-      modalContent: 'Start video chat?',
-      confirmBtnText: 'Accept',
-      declineBtnText: 'Decline',
-      isActive: true,
-      peerId: null,
-      socketEvent: 'video request accepted'
-    }
-    dispatch(setModal(modalData))
-  }, [dispatch])
+  // const handleStartVideoInvite = useCallback(() => {
+  //   console.log('invitation received')
+  //   const modalData = {
+  //     modalName: 'start video chat',
+  //     modalContent: 'Start video chat?',
+  //     confirmBtnText: 'Accept',
+  //     declineBtnText: 'Decline',
+  //     isActive: true,
+  //     peerId: null,
+  //     socketEvent: 'video request accepted'
+  //   }
+  //   dispatch(setModal(modalData))
+  // }, [dispatch])
 
   const handleCloseChatRoom = useCallback(() => {
     navigate('/')
@@ -124,7 +127,7 @@ const App: React.FC = () => {
     socket.on('invite requested', handleInviteRequested)
     socket.on('invite declined', handleInviteDeclined)
     socket.on('enter chat room', handleEnterChat)
-    socket.on('start video invite', handleStartVideoInvite)
+    // socket.on('start video invite', handleStartVideoInvite)
     socket.on('close chat room', handleCloseChatRoom)
 
     return () => {
@@ -133,7 +136,7 @@ const App: React.FC = () => {
       socket.off('invite requested', handleInviteRequested)
       socket.off('invite declined', handleInviteDeclined)
       socket.off('enter chat room', handleEnterChat)
-      socket.off('start video invite', handleStartVideoInvite)
+      // socket.off('start video invite', handleStartVideoInvite)
       socket.off('closeChatRoom', handleCloseChatRoom)
     }
   }, 
@@ -143,7 +146,7 @@ const App: React.FC = () => {
   handleInviteRequested,
   handleInviteDeclined,
   handleEnterChat,
-  handleStartVideoInvite,
+  // handleStartVideoInvite,
   handleCloseChatRoom])
  
   return (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ const App: React.FC = () => {
   const navigate = useNavigate()
 
   const activeUsers = useAppSelector(state => state.activeUsers.users)
+  const currentUser = useAppSelector(state => state.user.socketId)
 
   const handleSetNewUser = useCallback((usernameFromLocalStorage) => {
     dispatch(setNewUser(usernameFromLocalStorage))
@@ -81,23 +82,11 @@ const App: React.FC = () => {
     dispatch(resetNotification())
     dispatch(setRoom({ roomId: roomData.roomId, users: roomData.users }))
     navigate(`/p-room/${roomData.roomId}`)
-    // need to make sure that only one user calls handleSendVideoInvite
-    handleSendVideoInvite()
-  }, [dispatch, navigate])
-
-  // const handleStartVideoInvite = useCallback(() => {
-  //   console.log('invitation received')
-  //   const modalData = {
-  //     modalName: 'start video chat',
-  //     modalContent: 'Start video chat?',
-  //     confirmBtnText: 'Accept',
-  //     declineBtnText: 'Decline',
-  //     isActive: true,
-  //     peerId: null,
-  //     socketEvent: 'video request accepted'
-  //   }
-  //   dispatch(setModal(modalData))
-  // }, [dispatch])
+    if (roomData.users[0] === currentUser) {
+      // Start RTC Peer Connection
+      handleSendVideoInvite()
+    }
+  }, [dispatch, navigate, currentUser])
 
   const handleCloseChatRoom = useCallback(() => {
     navigate('/')
@@ -127,7 +116,6 @@ const App: React.FC = () => {
     socket.on('invite requested', handleInviteRequested)
     socket.on('invite declined', handleInviteDeclined)
     socket.on('enter chat room', handleEnterChat)
-    // socket.on('start video invite', handleStartVideoInvite)
     socket.on('close chat room', handleCloseChatRoom)
 
     return () => {
@@ -136,7 +124,6 @@ const App: React.FC = () => {
       socket.off('invite requested', handleInviteRequested)
       socket.off('invite declined', handleInviteDeclined)
       socket.off('enter chat room', handleEnterChat)
-      // socket.off('start video invite', handleStartVideoInvite)
       socket.off('closeChatRoom', handleCloseChatRoom)
     }
   }, 
@@ -146,7 +133,6 @@ const App: React.FC = () => {
   handleInviteRequested,
   handleInviteDeclined,
   handleEnterChat,
-  // handleStartVideoInvite,
   handleCloseChatRoom])
  
   return (

--- a/frontend/src/app/features/roomSlice.ts
+++ b/frontend/src/app/features/roomSlice.ts
@@ -3,7 +3,8 @@ import { Room } from './types'
 
 const initialState: Room = {
   roomId: '',
-  users: []
+  users: [],
+  isChatVisible: false
 }
 
 export const roomSlice = createSlice({
@@ -14,6 +15,9 @@ export const roomSlice = createSlice({
       state.roomId = action.payload.roomId
       state.users = state.users.concat(action.payload.users)
     },
+    setChatVisbility: (state, action: PayloadAction<boolean>) => {
+      state.isChatVisible = action.payload
+    },
     resetRoom: (state) => {
       state.roomId = ''
       state.users = []
@@ -21,6 +25,6 @@ export const roomSlice = createSlice({
   }
 })
 
-export const { setRoom, resetRoom } = roomSlice.actions
+export const { setRoom, resetRoom, setChatVisbility } = roomSlice.actions
 
 export default roomSlice.reducer

--- a/frontend/src/app/features/roomSlice.ts
+++ b/frontend/src/app/features/roomSlice.ts
@@ -4,7 +4,7 @@ import { Room, Message } from './types'
 const initialState: Room = {
   roomId: '',
   users: [],
-  isChatVisible: false,
+  isTextChatVisible: false,
   messages: [],
 }
 
@@ -17,7 +17,7 @@ export const roomSlice = createSlice({
       state.users = state.users.concat(action.payload.users)
     },
     setChatVisbility: (state, action: PayloadAction<boolean>) => {
-      state.isChatVisible = action.payload
+      state.isTextChatVisible = action.payload
     },
     addMessage: (state, action: PayloadAction<Message>) => {
       state.messages = state.messages.concat(action.payload)
@@ -25,7 +25,7 @@ export const roomSlice = createSlice({
     resetRoom: (state) => {
       state.roomId = ''
       state.users = []
-      state.isChatVisible = false
+      state.isTextChatVisible = false
       state.messages = []
     }
   }

--- a/frontend/src/app/features/roomSlice.ts
+++ b/frontend/src/app/features/roomSlice.ts
@@ -3,8 +3,7 @@ import { Room } from './types'
 
 const initialState: Room = {
   roomId: '',
-  users: [],
-  isVideoOn: false
+  users: []
 }
 
 export const roomSlice = createSlice({
@@ -15,17 +14,13 @@ export const roomSlice = createSlice({
       state.roomId = action.payload.roomId
       state.users = state.users.concat(action.payload.users)
     },
-    setVideoState: (state, action: PayloadAction<boolean>) => {
-      state.isVideoOn = action.payload
-    },
     resetRoom: (state) => {
       state.roomId = ''
       state.users = []
-      state.isVideoOn = false
     }
   }
 })
 
-export const { setRoom, resetRoom, setVideoState } = roomSlice.actions
+export const { setRoom, resetRoom } = roomSlice.actions
 
 export default roomSlice.reducer

--- a/frontend/src/app/features/roomSlice.ts
+++ b/frontend/src/app/features/roomSlice.ts
@@ -25,6 +25,7 @@ export const roomSlice = createSlice({
     resetRoom: (state) => {
       state.roomId = ''
       state.users = []
+      state.isChatVisible = false
       state.messages = []
     }
   }

--- a/frontend/src/app/features/roomSlice.ts
+++ b/frontend/src/app/features/roomSlice.ts
@@ -1,3 +1,6 @@
+/**
+ * Room state and action creators
+ */
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { Room, Message } from './types'
 

--- a/frontend/src/app/features/roomSlice.ts
+++ b/frontend/src/app/features/roomSlice.ts
@@ -1,10 +1,11 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { Room } from './types'
+import { Room, Message } from './types'
 
 const initialState: Room = {
   roomId: '',
   users: [],
-  isChatVisible: false
+  isChatVisible: false,
+  messages: [],
 }
 
 export const roomSlice = createSlice({
@@ -18,13 +19,17 @@ export const roomSlice = createSlice({
     setChatVisbility: (state, action: PayloadAction<boolean>) => {
       state.isChatVisible = action.payload
     },
+    addMessage: (state, action: PayloadAction<Message>) => {
+      state.messages = state.messages.concat(action.payload)
+    },
     resetRoom: (state) => {
       state.roomId = ''
       state.users = []
+      state.messages = []
     }
   }
 })
 
-export const { setRoom, resetRoom, setChatVisbility } = roomSlice.actions
+export const { setRoom, resetRoom, setChatVisbility, addMessage } = roomSlice.actions
 
 export default roomSlice.reducer

--- a/frontend/src/app/features/types.ts
+++ b/frontend/src/app/features/types.ts
@@ -28,4 +28,11 @@ export interface Room {
   roomId: string;
   users: string[];
   isChatVisible: boolean;
+  messages: Message[];
+}
+
+export interface Message {
+  content: string;
+  id: number;
+  className: string;
 }

--- a/frontend/src/app/features/types.ts
+++ b/frontend/src/app/features/types.ts
@@ -27,5 +27,4 @@ export interface Notification {
 export interface Room {
   roomId: string;
   users: string[];
-  isVideoOn: boolean;
 }

--- a/frontend/src/app/features/types.ts
+++ b/frontend/src/app/features/types.ts
@@ -27,7 +27,7 @@ export interface Notification {
 export interface Room {
   roomId: string;
   users: string[];
-  isChatVisible: boolean;
+  isTextChatVisible: boolean;
   messages: Message[];
 }
 

--- a/frontend/src/app/features/types.ts
+++ b/frontend/src/app/features/types.ts
@@ -27,4 +27,5 @@ export interface Notification {
 export interface Room {
   roomId: string;
   users: string[];
+  isChatVisible: boolean;
 }

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -3,7 +3,6 @@ import { useLocation } from "react-router-dom";
 
 const Header = () => {
   const location = useLocation()
-  console.log('location header', location.pathname)
   return (
     <div id="header">
       {location.pathname === "/" && <h1 className="title is-1 has-text-centered">Chat App</h1>}

--- a/frontend/src/components/Layout/Modal.tsx
+++ b/frontend/src/components/Layout/Modal.tsx
@@ -26,9 +26,9 @@ const ActionModal: React.FC = () => {
       handleInviteAccepted(modalData.peerId!)
     }
 
-    if (modalData.modalName === 'start video chat') {
-      handleSendVideoInvite()
-    }
+    // if (modalData.modalName === 'start video chat') {
+    //   handleSendVideoInvite()
+    // }
     
     dispatch(resetModal())
   }

--- a/frontend/src/components/Layout/Modal.tsx
+++ b/frontend/src/components/Layout/Modal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { resetModal } from '../../app/features/modalSlice';
 import { User } from '../../app/features/types'
 import { useAppSelector, useAppDispatch } from '../../app/hooks';
-import { handleSendInvite, handleInviteAccepted, handleDeclineInvite, handleSendVideoInvite } from '../../services/publishers';
+import { handleSendInvite, handleInviteAccepted, handleDeclineInvite } from '../../services/publishers';
 
 const ActionModal: React.FC = () => {
   const dispatch = useAppDispatch();

--- a/frontend/src/components/MessageForm.tsx
+++ b/frontend/src/components/MessageForm.tsx
@@ -1,3 +1,6 @@
+/**
+ * Chat Message Text Input and Submit
+ */
 import React, { useContext } from "react";
 import { SocketContext } from "../context/socket";
 import { useAppSelector } from '../app/hooks';

--- a/frontend/src/components/MessagesDisplay/Message.tsx
+++ b/frontend/src/components/MessagesDisplay/Message.tsx
@@ -1,3 +1,6 @@
+/**
+ * Chat text message
+ */
 import React, { memo } from "react";
 
 interface MessageProps {

--- a/frontend/src/components/MessagesDisplay/index.tsx
+++ b/frontend/src/components/MessagesDisplay/index.tsx
@@ -1,44 +1,15 @@
-import React, { useContext, useEffect, useCallback, useRef } from "react";
-import { SocketContext } from "../../context/socket";
+import React, { useEffect, useRef } from "react";
 import Message from './Message';
-import { useAppSelector, useAppDispatch } from '../../app/hooks';
-import { addMessage } from "../../app/features/roomSlice";
+import { useAppSelector } from '../../app/hooks';
 
 const MessagesDisplay: React.FC = () => {
-  const dispatch = useAppDispatch()
-
-  const socket = useContext(SocketContext)
-  const userId = useAppSelector(state => state.user.socketId)
   const messages = useAppSelector(state => state.room.messages)
 
   const messageEndRef = useRef<null | HTMLDivElement>(null)
 
-  const generateRandomNum = () => {
-    return Math.floor((Math.random() * 10000))
-  }
-
   const scrollToBottom = () => {
     messageEndRef.current!.scrollIntoView({ behavior: 'smooth'})
   }
-
-  const updateMessages = useCallback((message) => {
-    dispatch(addMessage(message))
-  }, [dispatch])
-
-  useEffect(() => {
-    socket.once('receive chat message', ( messageData ) => {
-      console.log('received message')
-      const firstMessageClassName = messages.length === 0 ? 'mt-auto' : ''
-      const userClassName = messageData.userId === userId ? 'peer1Message' : 'peer2Message'
-      const newMessage = {
-        content: messageData.msg,
-        userId: messageData.userId,
-        className: `${firstMessageClassName} ${userClassName}`,
-        id: generateRandomNum()
-      }
-      updateMessages(newMessage)
-    })
-  }, [socket, messages, userId, updateMessages])
 
   useEffect(() => {
     scrollToBottom()

--- a/frontend/src/components/MessagesDisplay/index.tsx
+++ b/frontend/src/components/MessagesDisplay/index.tsx
@@ -4,19 +4,12 @@ import Message from './Message';
 import { useAppSelector, useAppDispatch } from '../../app/hooks';
 import { addMessage } from "../../app/features/roomSlice";
 
-// export interface message {
-//   content: string;
-//   id: number;
-//   className: string;
-// }
-
 const MessagesDisplay: React.FC = () => {
   const dispatch = useAppDispatch()
 
   const socket = useContext(SocketContext)
   const userId = useAppSelector(state => state.user.socketId)
   const messages = useAppSelector(state => state.room.messages)
-  // const [messages, setMessages] = useState<message[]>([])
 
   const messageEndRef = useRef<null | HTMLDivElement>(null)
 
@@ -44,8 +37,6 @@ const MessagesDisplay: React.FC = () => {
         id: generateRandomNum()
       }
       updateMessages(newMessage)
-      // dispatch(addMessage(newMessage))
-      // setMessages(messages.concat(newMessage))
     })
   }, [socket, messages, userId, updateMessages])
 

--- a/frontend/src/components/MessagesDisplay/index.tsx
+++ b/frontend/src/components/MessagesDisplay/index.tsx
@@ -1,6 +1,9 @@
+/**
+ * Chat text message display
+ */
 import React, { useEffect, useRef } from "react";
-import Message from './Message';
 import { useAppSelector } from '../../app/hooks';
+import Message from './Message';
 
 const MessagesDisplay: React.FC = () => {
   const messages = useAppSelector(state => state.room.messages)
@@ -20,7 +23,6 @@ const MessagesDisplay: React.FC = () => {
       {messages.map(message => <Message message={message.content} key={message.id} className={message.className}/>)}
       <div ref={messageEndRef} />
     </div>
-    
   )
 }
 

--- a/frontend/src/components/RoomOptions.tsx
+++ b/frontend/src/components/RoomOptions.tsx
@@ -1,11 +1,10 @@
 import React, { useContext } from "react";
-import { setVideoState } from "../app/features/roomSlice";
-import { useAppSelector, useAppDispatch } from '../app/hooks';
+import { useAppSelector } from '../app/hooks';
 import { SocketContext } from "../context/socket";
 
 const RoomOptions = () => {
   const socket = useContext(SocketContext)
-  const dispatch = useAppDispatch()
+  // const dispatch = useAppDispatch()
 
   const room = useAppSelector(state => state.room)
 
@@ -14,16 +13,15 @@ const RoomOptions = () => {
     socket.emit('end chat', room.roomId)
   }
 
-  const handleStartVideoClick = () => {
-    console.log('start video')
-    dispatch(setVideoState(true))
-    socket.emit('start video request', room.users)
-  }
+  // const handleStartVideoClick = () => {
+  //   console.log('start video')
+  //   dispatch(setVideoState(true))
+  //   socket.emit('start video request', room.users)
+  // }
 
   return (
     <div className="mt-4 mb-4 is-flex is-flex-direction-row is-justify-content-center">
       <button className="button is-danger mr-1" onClick={handleEndClick}>End Chat</button>
-      {!room.isVideoOn && <button className="button is-link ml-1" onClick={handleStartVideoClick}>Start Video</button>}
     </div>
   )
 }

--- a/frontend/src/components/RoomOptions.tsx
+++ b/frontend/src/components/RoomOptions.tsx
@@ -1,12 +1,14 @@
 import React, { useContext } from "react";
-import { useAppSelector } from '../app/hooks';
+import { setChatVisbility } from "../app/features/roomSlice";
+import { useAppSelector, useAppDispatch } from '../app/hooks';
 import { SocketContext } from "../context/socket";
 
 const RoomOptions = () => {
   const socket = useContext(SocketContext)
-  // const dispatch = useAppDispatch()
+  const dispatch = useAppDispatch()
 
   const room = useAppSelector(state => state.room)
+  const isChatVisible = useAppSelector(state => state.room.isChatVisible)
 
   const handleEndClick = () => {
     console.log('end chat')
@@ -14,13 +16,13 @@ const RoomOptions = () => {
   }
 
   const handleToggleChat = () => {
-    console.log('toggle chat')
+    dispatch(setChatVisbility(!isChatVisible))
   }
 
   return (
     <div className="mt-4 mb-4 is-flex is-flex-direction-row is-justify-content-center">
       <button className="button is-danger mr-1" onClick={handleEndClick}>End Chat</button>
-      <button className="button is-primary mr-1" onClick={handleToggleChat}>Show Chat</button>
+      <button className="button is-primary mr-1" onClick={handleToggleChat}>{isChatVisible ? 'Hide Chat' : 'Show Chat'}</button>
     </div>
   )
 }

--- a/frontend/src/components/RoomOptions.tsx
+++ b/frontend/src/components/RoomOptions.tsx
@@ -1,7 +1,10 @@
+/**
+ * Private room button menu
+ */
 import React, { useContext } from "react";
-import { setChatVisbility } from "../app/features/roomSlice";
-import { useAppSelector, useAppDispatch } from '../app/hooks';
 import { SocketContext } from "../context/socket";
+import { useAppSelector, useAppDispatch } from '../app/hooks';
+import { setChatVisbility } from "../app/features/roomSlice";
 
 const RoomOptions = () => {
   const socket = useContext(SocketContext)
@@ -11,7 +14,6 @@ const RoomOptions = () => {
   const isChatVisible = useAppSelector(state => state.room.isChatVisible)
 
   const handleEndClick = () => {
-    console.log('end chat')
     socket.emit('end chat', room.roomId)
   }
 

--- a/frontend/src/components/RoomOptions.tsx
+++ b/frontend/src/components/RoomOptions.tsx
@@ -13,15 +13,14 @@ const RoomOptions = () => {
     socket.emit('end chat', room.roomId)
   }
 
-  // const handleStartVideoClick = () => {
-  //   console.log('start video')
-  //   dispatch(setVideoState(true))
-  //   socket.emit('start video request', room.users)
-  // }
+  const handleToggleChat = () => {
+    console.log('toggle chat')
+  }
 
   return (
     <div className="mt-4 mb-4 is-flex is-flex-direction-row is-justify-content-center">
       <button className="button is-danger mr-1" onClick={handleEndClick}>End Chat</button>
+      <button className="button is-primary mr-1" onClick={handleToggleChat}>Show Chat</button>
     </div>
   )
 }

--- a/frontend/src/components/RoomOptions.tsx
+++ b/frontend/src/components/RoomOptions.tsx
@@ -11,20 +11,20 @@ const RoomOptions = () => {
   const dispatch = useAppDispatch()
 
   const room = useAppSelector(state => state.room)
-  const isChatVisible = useAppSelector(state => state.room.isChatVisible)
+  const isTextChatVisible = useAppSelector(state => state.room.isTextChatVisible)
 
   const handleEndClick = () => {
     socket.emit('end chat', room.roomId)
   }
 
   const handleToggleChat = () => {
-    dispatch(setChatVisbility(!isChatVisible))
+    dispatch(setChatVisbility(!isTextChatVisible))
   }
 
   return (
     <div className="mt-4 mb-4 is-flex is-flex-direction-row is-justify-content-center">
       <button className="button is-danger mr-1" onClick={handleEndClick}>End Chat</button>
-      <button className="button is-primary mr-1" onClick={handleToggleChat}>{isChatVisible ? 'Hide Chat' : 'Show Chat'}</button>
+      <button className="button is-primary mr-1" onClick={handleToggleChat}>{isTextChatVisible ? 'Hide Chat' : 'Show Chat'}</button>
     </div>
   )
 }

--- a/frontend/src/components/VideoDisplay.tsx
+++ b/frontend/src/components/VideoDisplay.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useContext, useRef, useCallback, useMemo } from "react";
 import { SocketContext } from "../context/socket";
 import { useAppDispatch } from '../app/hooks';
-import { setVideoState } from "../app/features/roomSlice";
 
 const VideoDisplay = () => {
   const socket = useContext(SocketContext);
@@ -211,7 +210,6 @@ const VideoDisplay = () => {
 
     socket.on('get video offer', (sdp: RTCSessionDescription) => {
       handleVideoChatOffer(sdp);
-      dispatch(setVideoState(true))
     })
 
     socket.on('get video answer', (sdp: RTCSessionDescription) => {
@@ -225,7 +223,6 @@ const VideoDisplay = () => {
     socket.on('end video request', () => {
       console.log('received end video request')
       closeVideoConnection()
-      dispatch(setVideoState(false))
     })
 
   }, [socket, dispatch, startVideoChat, handleVideoChatOffer, handleVideoChatAnswer, handleNewICECandidate])

--- a/frontend/src/components/VideoDisplay.tsx
+++ b/frontend/src/components/VideoDisplay.tsx
@@ -266,11 +266,11 @@ const VideoDisplay = () => {
   }
 
   return (
-    <div className="is-flex is-flex-direction-row is-justify-content-space-evenly">
-      <div className="videoWrapper m-1">
+    <div className="is-flex is-flex-direction-column is-justify-content-space-evenly is-align-items-center">
+      <div className="videoWrapper local m-1">
         <video ref={el => { localStreamRef.current = el}} id="videoStream" autoPlay>There is a problem playing the video.</video>
       </div>
-      <div className="videoWrapper m-1">
+      <div className="videoWrapper remote m-1">
         <video ref={el => { remoteStreamRef.current = el}} id="remoteVideoStream" autoPlay>There is a problem playing the video.</video>
       </div>
     </div>

--- a/frontend/src/components/VideoDisplay.tsx
+++ b/frontend/src/components/VideoDisplay.tsx
@@ -1,3 +1,7 @@
+/**
+ * Local and remote video stream display
+ * RTC Peer connection handling
+ */
 import React, { useEffect, useContext, useRef, useCallback, useMemo } from "react";
 import { SocketContext } from "../context/socket";
 import { useAppDispatch } from '../app/hooks';
@@ -198,7 +202,7 @@ const VideoDisplay = () => {
         localStreamRef.current.srcObject = webcamStreamRef.current;
       }
     } catch (err) {
-      console.log('error in enterVideoChat - local webcam stream', err)
+      console.log('error in startVideoChat', err)
     }
   }, [createPeerConnection, mediaConstraints])
 
@@ -221,9 +225,16 @@ const VideoDisplay = () => {
     })
 
     socket.on('end video request', () => {
-      console.log('received end video request')
       closeVideoConnection()
     })
+
+    return () => {
+      socket.off('video ready')
+      socket.off('get video offer')
+      socket.off('get video answer')
+      socket.off('get candidate')
+      socket.off('end video request')
+    }
 
   }, [socket, dispatch, startVideoChat, handleVideoChatOffer, handleVideoChatAnswer, handleNewICECandidate])
 

--- a/frontend/src/pages/PrivateRoom.tsx
+++ b/frontend/src/pages/PrivateRoom.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useContext } from 'react';
 import Layout from '../components/Layout';
 import { setNotification, resetNotification } from '../app/features/notificationSlice';
 import { useAppSelector, useAppDispatch } from '../app/hooks';
-import MessageForm from '../components/MessageForm';
-import MessagesDisplay from '../components/MessagesDisplay';
+// import MessageForm from '../components/MessageForm';
+// import MessagesDisplay from '../components/MessagesDisplay';
 import RoomOptions from '../components/RoomOptions';
 import { Navigate } from 'react-router-dom';
 import { SocketContext } from '../context/socket';
@@ -38,9 +38,9 @@ const PrivateRoom = () => {
         ? 
           <>
             <RoomOptions />
-            {room.isVideoOn && <VideoDisplay />}    
-            <MessagesDisplay />
-            <MessageForm />
+            <VideoDisplay />
+            {/* <MessagesDisplay />
+            <MessageForm /> */}
           </>
         : <p>No access</p>}
       </Layout>

--- a/frontend/src/pages/PrivateRoom.tsx
+++ b/frontend/src/pages/PrivateRoom.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useEffect, useContext, useCallback } from 'react';
 import Layout from '../components/Layout';
 import { setNotification, resetNotification } from '../app/features/notificationSlice';
 import { useAppSelector, useAppDispatch } from '../app/hooks';
@@ -8,18 +8,40 @@ import RoomOptions from '../components/RoomOptions';
 import { Navigate } from 'react-router-dom';
 import { SocketContext } from '../context/socket';
 import VideoDisplay from '../components/VideoDisplay';
+import { addMessage } from "../app/features/roomSlice";
+import { generateRandomNum } from '../util/helper';
 
 const PrivateRoom = () => {
   const socket = useContext(SocketContext)
   const dispatch = useAppDispatch()
+  
   const room = useAppSelector(state  => state.room)
   const userId = useAppSelector(state => state.user.socketId)
   const isChatVisible = useAppSelector(state => state.room.isChatVisible)
+  const messages = useAppSelector(state => state.room.messages)
 
   useEffect(() => {
     socket.removeAllListeners('enter chat room')
   }, [socket])
   const userHasAccess = room.users.includes(userId)
+
+  const updateMessages = useCallback((message) => {
+    dispatch(addMessage(message))
+  }, [dispatch])
+
+  useEffect(() => {
+    socket.once('receive chat message', ( messageData ) => {
+      const firstMessageClassName = messages.length === 0 ? 'mt-auto' : ''
+      const userClassName = messageData.userId === userId ? 'peer1Message' : 'peer2Message'
+      const newMessage = {
+        content: messageData.msg,
+        userId: messageData.userId,
+        className: `${firstMessageClassName} ${userClassName}`,
+        id: generateRandomNum()
+      }
+      updateMessages(newMessage)
+    })
+  }, [socket, messages, userId, updateMessages])
 
   if (!userHasAccess) {
     const notificationData = {

--- a/frontend/src/pages/PrivateRoom.tsx
+++ b/frontend/src/pages/PrivateRoom.tsx
@@ -20,7 +20,7 @@ const PrivateRoom = () => {
   
   const room = useAppSelector(state  => state.room)
   const userId = useAppSelector(state => state.user.socketId)
-  const isChatVisible = useAppSelector(state => state.room.isChatVisible)
+  const isTextChatVisible = useAppSelector(state => state.room.isTextChatVisible)
   const messages = useAppSelector(state => state.room.messages)
 
   const userHasAccess = room.users.includes(userId)
@@ -54,7 +54,7 @@ const PrivateRoom = () => {
       isLoading: false,
       isActive: true,
       }
-      
+
     dispatch(setNotification(notificationData))
     setTimeout(() => dispatch(resetNotification()), 5000)
     return <Navigate to="/" />
@@ -69,7 +69,7 @@ const PrivateRoom = () => {
             <div className="privateRoomContent bulma-overlay-mixin-parent">
               <VideoDisplay />
               {
-                isChatVisible &&
+                isTextChatVisible &&
                 <div className="chat bulma-overlay-mixin">
                   <MessagesDisplay />
                   <MessageForm />

--- a/frontend/src/pages/PrivateRoom.tsx
+++ b/frontend/src/pages/PrivateRoom.tsx
@@ -1,14 +1,17 @@
+/**
+ * Private video and text message chat room between two peers
+ */
 import React, { useEffect, useContext, useCallback } from 'react';
-import Layout from '../components/Layout';
-import { setNotification, resetNotification } from '../app/features/notificationSlice';
-import { useAppSelector, useAppDispatch } from '../app/hooks';
-import MessageForm from '../components/MessageForm';
-import MessagesDisplay from '../components/MessagesDisplay';
-import RoomOptions from '../components/RoomOptions';
 import { Navigate } from 'react-router-dom';
 import { SocketContext } from '../context/socket';
-import VideoDisplay from '../components/VideoDisplay';
+import { useAppSelector, useAppDispatch } from '../app/hooks';
+import { setNotification, resetNotification } from '../app/features/notificationSlice';
 import { addMessage } from "../app/features/roomSlice";
+import Layout from '../components/Layout';
+import RoomOptions from '../components/RoomOptions';
+import VideoDisplay from '../components/VideoDisplay';
+import MessagesDisplay from '../components/MessagesDisplay';
+import MessageForm from '../components/MessageForm';
 import { generateRandomNum } from '../util/helper';
 
 const PrivateRoom = () => {
@@ -20,15 +23,16 @@ const PrivateRoom = () => {
   const isChatVisible = useAppSelector(state => state.room.isChatVisible)
   const messages = useAppSelector(state => state.room.messages)
 
-  useEffect(() => {
-    socket.removeAllListeners('enter chat room')
-  }, [socket])
   const userHasAccess = room.users.includes(userId)
 
-  const updateMessages = useCallback((message) => {
+  const setMessages = useCallback((message) => {
     dispatch(addMessage(message))
   }, [dispatch])
 
+  useEffect(() => {
+    socket.removeAllListeners('enter chat room')
+  }, [socket])
+  
   useEffect(() => {
     socket.once('receive chat message', ( messageData ) => {
       const firstMessageClassName = messages.length === 0 ? 'mt-auto' : ''
@@ -39,9 +43,9 @@ const PrivateRoom = () => {
         className: `${firstMessageClassName} ${userClassName}`,
         id: generateRandomNum()
       }
-      updateMessages(newMessage)
+      setMessages(newMessage)
     })
-  }, [socket, messages, userId, updateMessages])
+  }, [socket, messages, userId, setMessages])
 
   if (!userHasAccess) {
     const notificationData = {
@@ -50,6 +54,7 @@ const PrivateRoom = () => {
       isLoading: false,
       isActive: true,
       }
+      
     dispatch(setNotification(notificationData))
     setTimeout(() => dispatch(resetNotification()), 5000)
     return <Navigate to="/" />

--- a/frontend/src/pages/PrivateRoom.tsx
+++ b/frontend/src/pages/PrivateRoom.tsx
@@ -39,14 +39,16 @@ const PrivateRoom = () => {
         ? 
           <>
             <RoomOptions />
-            <VideoDisplay />
-            {
-              isChatVisible &&
-              <div>
-                <MessagesDisplay />
-                <MessageForm />
-              </div>
-            }
+            <div className="privateRoomContent bulma-overlay-mixin-parent">
+              <VideoDisplay />
+              {
+                isChatVisible &&
+                <div className="chat bulma-overlay-mixin">
+                  <MessagesDisplay />
+                  <MessageForm />
+                </div>
+              }
+            </div>
           </>
         : <p>No access</p>}
       </Layout>

--- a/frontend/src/pages/PrivateRoom.tsx
+++ b/frontend/src/pages/PrivateRoom.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useContext } from 'react';
 import Layout from '../components/Layout';
 import { setNotification, resetNotification } from '../app/features/notificationSlice';
 import { useAppSelector, useAppDispatch } from '../app/hooks';
-// import MessageForm from '../components/MessageForm';
-// import MessagesDisplay from '../components/MessagesDisplay';
+import MessageForm from '../components/MessageForm';
+import MessagesDisplay from '../components/MessagesDisplay';
 import RoomOptions from '../components/RoomOptions';
 import { Navigate } from 'react-router-dom';
 import { SocketContext } from '../context/socket';
@@ -14,6 +14,7 @@ const PrivateRoom = () => {
   const dispatch = useAppDispatch()
   const room = useAppSelector(state  => state.room)
   const userId = useAppSelector(state => state.user.socketId)
+  const isChatVisible = useAppSelector(state => state.room.isChatVisible)
 
   useEffect(() => {
     socket.removeAllListeners('enter chat room')
@@ -39,8 +40,13 @@ const PrivateRoom = () => {
           <>
             <RoomOptions />
             <VideoDisplay />
-            {/* <MessagesDisplay />
-            <MessageForm /> */}
+            {
+              isChatVisible &&
+              <div>
+                <MessagesDisplay />
+                <MessageForm />
+              </div>
+            }
           </>
         : <p>No access</p>}
       </Layout>

--- a/frontend/src/pages/PrivateRoom.tsx
+++ b/frontend/src/pages/PrivateRoom.tsx
@@ -29,23 +29,29 @@ const PrivateRoom = () => {
     dispatch(addMessage(message))
   }, [dispatch])
 
+  const handleReceiveChatMessage = useCallback(( messageData ) => {
+    const firstMessageClassName = messages.length === 0 ? 'mt-auto' : ''
+    const userClassName = messageData.userId === userId ? 'peer1Message' : 'peer2Message'
+    const newMessage = {
+      content: messageData.msg,
+      userId: messageData.userId,
+      className: `${firstMessageClassName} ${userClassName}`,
+      id: generateRandomNum()
+    }
+    setMessages(newMessage)
+  }, [messages.length, setMessages, userId])
+
   useEffect(() => {
     socket.removeAllListeners('enter chat room')
   }, [socket])
   
   useEffect(() => {
-    socket.once('receive chat message', ( messageData ) => {
-      const firstMessageClassName = messages.length === 0 ? 'mt-auto' : ''
-      const userClassName = messageData.userId === userId ? 'peer1Message' : 'peer2Message'
-      const newMessage = {
-        content: messageData.msg,
-        userId: messageData.userId,
-        className: `${firstMessageClassName} ${userClassName}`,
-        id: generateRandomNum()
-      }
-      setMessages(newMessage)
-    })
-  }, [socket, messages, userId, setMessages])
+    socket.once('receive chat message', handleReceiveChatMessage)
+
+    return () => {
+      socket.off('receive chat message', handleReceiveChatMessage)
+    }
+  }, [socket, messages, userId, setMessages, handleReceiveChatMessage])
 
   if (!userHasAccess) {
     const notificationData = {

--- a/frontend/src/services/publishers.ts
+++ b/frontend/src/services/publishers.ts
@@ -36,6 +36,8 @@ export const handleDeclineInvite = (peerId: string) => {
   socket.emit('decline invite', peerId)
 }
 
+// this event starts the RTC peer connection sequence
 export const handleSendVideoInvite = () => {
+  console.log('starting RTC peer connection sequence')
   socket.emit('video request accepted')
 }

--- a/frontend/src/services/publishers.ts
+++ b/frontend/src/services/publishers.ts
@@ -1,7 +1,6 @@
 import { socket } from "../context/socket"
 import { setNotification } from "../app/features/notificationSlice"
 import { setModal } from "../app/features/modalSlice";
-import { setVideoState } from "../app/features/roomSlice";
 import { store } from "../app/store";
 
 export const handleInviteToChatClick = (peerId: string, peerUsername: string) => {
@@ -38,6 +37,5 @@ export const handleDeclineInvite = (peerId: string) => {
 }
 
 export const handleSendVideoInvite = () => {
-  store.dispatch(setVideoState(true))
   socket.emit('video request accepted')
 }

--- a/frontend/src/styles/app.scss
+++ b/frontend/src/styles/app.scss
@@ -28,6 +28,6 @@ body, html, #root, .App, .Layout {
   background-color: #F1F4FF;
 }
 
-.videoWrapper {
-  max-width: 200px;
+.videoWrapper.local{
+  max-width: 100px;
 }

--- a/frontend/src/styles/app.scss
+++ b/frontend/src/styles/app.scss
@@ -11,8 +11,13 @@ body, html, #root, .App, .Layout {
   height: 92vh;
 }
 
+.chat {
+  height: 60%;
+}
+
 #messageDisplay {
   overflow-y: auto;
+  height: 80%;
 }
 
 .Message {

--- a/frontend/src/styles/helpers/mixins.scss
+++ b/frontend/src/styles/helpers/mixins.scss
@@ -1,17 +1,17 @@
 .bulma-overlay-mixin {
   @include from(300px) {
-    @include overlay(2rem);
+    @include overlay(1rem);
+    transform: translateY(150px);
   }
-
   @include from(600px) {
     @include overlay(5rem);
+    transform: translateY(100px);
   }
-  background-color: darkorange;
+  background-color: lightgray;
   border-radius: 0.25em;
   color: white;
-  opacity: 0.9;
+  opacity: 0.95;
   padding: 1em;
-  z-index: 10;
 }
 
 .bulma-loader-mixin {

--- a/frontend/src/util/helper.tsx
+++ b/frontend/src/util/helper.tsx
@@ -1,0 +1,3 @@
+export const generateRandomNum = () => {
+  return Math.floor((Math.random() * 10000))
+}


### PR DESCRIPTION
### Description
This PR updates the private chat so that the video stream between the two peers start when they enter the room. The text chat is updated so that it can be toggled.

In the backend, the socket event handlers in pubsub/privateChat.ts were updated so that the peer video connection started when the users enter the room.

### Type
- [ ] New feature
- [x] Refactoring
- [ ] Bug-fix
- [ ] DevOps
- [ ] Testing

### Demo

https://user-images.githubusercontent.com/54559570/157052759-651c9bb6-7734-4320-afdc-40ca0688bcb3.mp4

### Testing
- Clone this branch and install dependencies
- If your MongoDB database is local make sure that it is running
- Run the development server `npm run dev`
- Open two Firefox browsers
- Go the page localhost:3000 in each browsers
- Initiate a private chat by clicking `Invite to Chat` in one of the browsers

Notes:
- May not work with Chrome
- Can work with one or two webcams.  If there is only one webcam, the local and remote feeds will be the same.
