### PR TITLE
clean database when server restarts

### DIFF
--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -22,6 +22,11 @@ if (process.env.NODE_ENV === 'test') {
 const main = async () => {
   try {
     await client.connect()
+
+    // clean database everytime the server restarts
+    await client.db('chat').collection('users').deleteMany({})
+    await client.db('chat').collection('room').deleteMany({})
+
     console.log('Connected to MongoDB')
   } catch(e) {
     console.log(e)


### PR DESCRIPTION
## Description

This PR resolved the problem during development where duplicate users are saved in the database when the server restarts. To fix this problem, the database is cleaned when the server starts.